### PR TITLE
user id made a string to avoid requests.exceptions.InvalidHeader

### DIFF
--- a/bugzilla2gitlab/config.py
+++ b/bugzilla2gitlab/config.py
@@ -49,7 +49,7 @@ def _load_user_id_cache(path, gitlab_url, gitlab_headers):
     for user in bugzilla_mapping:
         gitlab_username = bugzilla_mapping[user]
         uid = _get_user_id(gitlab_username, gitlab_url, gitlab_headers)
-        gitlab_users[gitlab_username] = uid
+        gitlab_users[gitlab_username] = str(uid)
 
     mappings = {}
     # bugzilla_username: gitlab_username


### PR DESCRIPTION
Started getting an exception after sync with upstream today:

```
Traceback (most recent call last):
  File "bin/bugzilla2gitlab", line 26, in <module>
    main()
  File "bin/bugzilla2gitlab", line 23, in main
    client.migrate(bugs)
  File "/usr/local/lib/python2.7/dist-packages/bugzilla2gitlab/migrator.py", line 18, in migrate
    self.migrate_one(bug)
  File "/usr/local/lib/python2.7/dist-packages/bugzilla2gitlab/migrator.py", line 27, in migrate_one
    issue_thread.save()
  File "/usr/local/lib/python2.7/dist-packages/bugzilla2gitlab/models.py", line 40, in save
    self.issue.save()
  File "/usr/local/lib/python2.7/dist-packages/bugzilla2gitlab/models.py", line 187, in save
    dry_run=conf.dry_run)
  File "/usr/local/lib/python2.7/dist-packages/bugzilla2gitlab/utils.py", line 30, in _perform_request
    result = func(url, params=params, data=data, headers=headers)
  File "/usr/local/lib/python2.7/dist-packages/requests/sessions.py", line 555, in post
    return self.request('POST', url, data=data, json=json, **kwargs)
  File "/usr/local/lib/python2.7/dist-packages/requests/sessions.py", line 494, in request
    prep = self.prepare_request(req)
  File "/usr/local/lib/python2.7/dist-packages/requests/sessions.py", line 437, in prepare_request
    hooks=merge_hooks(request.hooks, self.hooks),
  File "/usr/local/lib/python2.7/dist-packages/requests/models.py", line 306, in prepare
    self.prepare_headers(headers)
  File "/usr/local/lib/python2.7/dist-packages/requests/models.py", line 440, in prepare_headers
    check_header_validity(header)
  File "/usr/local/lib/python2.7/dist-packages/requests/utils.py", line 872, in check_header_validity
    "bytes, not %s" % (name, value, type(value)))
requests.exceptions.InvalidHeader: Value for header {sudo: 2} must be of type str or bytes, not <type 'int'>

```
Looks like requests library no longer accepts numeric header values. Proposed PR fixes this.