### PR TITLE
Feature/milestones

### DIFF
--- a/bugzilla2gitlab/config.py
+++ b/bugzilla2gitlab/config.py
@@ -10,6 +10,7 @@ Config = namedtuple('Config', ["gitlab_base_url", "gitlab_project_id",
                                "bugzilla_closed_states", "default_headers", "component_mappings",
                                "bugzilla_users", "gitlab_users", "gitlab_misc_user",
                                "default_gitlab_labels", "datetime_format_string",
+                               "map_milestones", "milestones_to_skip", "gitlab_milestones",
                                "dry_run", "include_bugzilla_link"])
 
 
@@ -18,6 +19,11 @@ def get_config(path):
     configuration.update(_load_defaults(path))
     configuration.update(_load_user_id_cache(path, configuration["gitlab_base_url"],
                                              configuration["default_headers"]))
+    if configuration["map_milestones"]:
+        configuration.update(
+            _load_milestone_id_cache(configuration["gitlab_project_id"],
+                                     configuration["gitlab_base_url"],
+                                     configuration["default_headers"]))
     configuration.update(_load_component_mappings(path))
     return Config(**configuration)
 
@@ -59,6 +65,22 @@ def _load_user_id_cache(path, gitlab_url, gitlab_headers):
     mappings["gitlab_users"] = gitlab_users
 
     return mappings
+
+
+def _load_milestone_id_cache(project_id, gitlab_url, gitlab_headers):
+    '''
+    Load cache of GitLab milestones and ids
+    '''
+    print("Loading milestone cache...")
+
+    gitlab_milestones = {}
+    url = "{}/projects/{}/milestones".format(gitlab_url, project_id)
+    result = _perform_request(url, "get", headers=gitlab_headers)
+    if result and isinstance(result, list):
+        for milestone in result:
+            gitlab_milestones[milestone["title"]] = milestone["id"]
+
+    return {"gitlab_milestones": gitlab_milestones}
 
 
 def _get_user_id(username, gitlab_url, headers):

--- a/bugzilla2gitlab/models.py
+++ b/bugzilla2gitlab/models.py
@@ -93,7 +93,8 @@ class Issue(object):
 
     def create_milestone(self, title):
         '''
-        Looks up milestone id given its title or creates a new one. Does nothing if milestones are not mapped.
+        Looks up milestone id given its title or creates a new one. Does nothing if milestones
+        are not mapped.
         '''
         if not conf.map_milestones or title in conf.milestones_to_skip:
             return

--- a/bugzilla2gitlab/models.py
+++ b/bugzilla2gitlab/models.py
@@ -100,7 +100,7 @@ class Issue(object):
 
         if title not in conf.gitlab_milestones:
             url = "{}/projects/{}/milestones".format(conf.gitlab_base_url, conf.gitlab_project_id)
-            response = _perform_request(url, "post", headers=conf.gitlab_headers, data={"title": title})
+            response = _perform_request(url, "post", headers=self.headers, data={"title": title})
             conf.gitlab_milestones[title] = response["id"]
 
         self.milestone_id = conf.gitlab_milestones[title]

--- a/tests/test_bugzilla2gitlab.py
+++ b/tests/test_bugzilla2gitlab.py
@@ -13,8 +13,12 @@ def test_config(monkeypatch):
     def mockreturn(username, gitlab_url, headers):
         return random.randint(0, 100)
 
+    def mockmilestones(project_id, gitlab_url, headers):
+        return {"gitlab_milestones": {"Foo": 1}}
+
     # monkeypatch config method that performs API calls to return a random int instead
     monkeypatch.setattr(bugzilla2gitlab.config, '_get_user_id', mockreturn)
+    monkeypatch.setattr(bugzilla2gitlab.config, '_load_milestone_id_cache', mockmilestones)
     conf = bugzilla2gitlab.config.get_config(os.path.join(TEST_DATA_PATH, "config"))
     assert isinstance(conf, bugzilla2gitlab.config.Config)
     '''
@@ -42,12 +46,24 @@ def test_config(monkeypatch):
     # conf.compnent mappings is a dictionary
     assert isinstance(conf.component_mappings, dict)
 
+    # conf.map_milestones is a boolean value
+    assert isinstance(conf.map_milestones, bool)
+
+    # conf.milestones_to_skip is a list
+    assert isinstance(conf.milestones_to_skip, list)
+
+    # conf.gitlab_milestones is a dictionary
+    assert isinstance(conf.gitlab_milestones, dict)
+
 
 def test_Migrator(monkeypatch):
     bug_id = 103
 
     def mock_getuserid(username, gitlab_url, headers):
         return random.randint(0, 100)
+
+    def mock_loadmilestoneidcache(project_id, gitlab_url, headers):
+        return {"gitlab_milestones": {"Foo": 1}}
 
     def mock_fetchbugcontent(url, bug_id):
         bug_file = "bug-{}.xml".format(bug_id)
@@ -57,6 +73,8 @@ def test_Migrator(monkeypatch):
 
     # monkeypatch config method that performs API calls to return a random int instead
     monkeypatch.setattr(bugzilla2gitlab.config, '_get_user_id', mock_getuserid)
+    monkeypatch.setattr(bugzilla2gitlab.config, '_load_milestone_id_cache',
+                        mock_loadmilestoneidcache)
     monkeypatch.setattr(bugzilla2gitlab.utils, '_fetch_bug_content', mock_fetchbugcontent)
 
     # just test that it works without throwing any exceptions

--- a/tests/test_data/config/defaults.yml
+++ b/tests/test_data/config/defaults.yml
@@ -46,3 +46,11 @@ default_gitlab_labels:
 
 # Include a link to the original bugzilla bug in the GitLab issue description
 include_bugzilla_link: true
+
+# Set to true to map bugzilla milestones to GitLab
+map_milestones: true
+
+# Do not map these bugzilla milestones to GitLab
+milestones_to_skip:
+    - "---"
+    - "UNKNOWN"


### PR DESCRIPTION
Added an ability to map bugzilla milestones to GitLab. `milestone` field was already declared for an issue but it should have been named `milestone_id` and pre-caching of GitLab milestones was necessary to map title to id.