### PR TITLE
add option to disable ssl certificate verification

### DIFF
--- a/bugzilla2gitlab/config.py
+++ b/bugzilla2gitlab/config.py
@@ -12,19 +12,21 @@ Config = namedtuple('Config', ["gitlab_base_url", "gitlab_project_id",
                                "default_gitlab_labels", "datetime_format_string",
                                "map_operating_system", "map_keywords", "keywords_to_skip",
                                "map_milestones", "milestones_to_skip", "gitlab_milestones",
-                               "dry_run", "include_bugzilla_link"])
+                               "dry_run", "include_bugzilla_link", "verify"])
 
 
 def get_config(path):
     configuration = {}
     configuration.update(_load_defaults(path))
     configuration.update(_load_user_id_cache(path, configuration["gitlab_base_url"],
-                                             configuration["default_headers"]))
+                                             configuration["default_headers"],
+                                             configuration['verify']))
     if configuration["map_milestones"]:
         configuration.update(
             _load_milestone_id_cache(configuration["gitlab_project_id"],
                                      configuration["gitlab_base_url"],
-                                     configuration["default_headers"]))
+                                     configuration["default_headers"],
+                                     configuration['verify']))
     configuration.update(_load_component_mappings(path))
     return Config(**configuration)
 
@@ -44,7 +46,7 @@ def _load_defaults(path):
     return defaults
 
 
-def _load_user_id_cache(path, gitlab_url, gitlab_headers):
+def _load_user_id_cache(path, gitlab_url, gitlab_headers, verify):
     '''
     Load cache of GitLab usernames and ids
     '''
@@ -55,7 +57,7 @@ def _load_user_id_cache(path, gitlab_url, gitlab_headers):
     gitlab_users = {}
     for user in bugzilla_mapping:
         gitlab_username = bugzilla_mapping[user]
-        uid = _get_user_id(gitlab_username, gitlab_url, gitlab_headers)
+        uid = _get_user_id(gitlab_username, gitlab_url, gitlab_headers, verify=verify)
         gitlab_users[gitlab_username] = str(uid)
 
     mappings = {}
@@ -68,7 +70,7 @@ def _load_user_id_cache(path, gitlab_url, gitlab_headers):
     return mappings
 
 
-def _load_milestone_id_cache(project_id, gitlab_url, gitlab_headers):
+def _load_milestone_id_cache(project_id, gitlab_url, gitlab_headers, verify):
     '''
     Load cache of GitLab milestones and ids
     '''
@@ -76,7 +78,7 @@ def _load_milestone_id_cache(project_id, gitlab_url, gitlab_headers):
 
     gitlab_milestones = {}
     url = "{}/projects/{}/milestones".format(gitlab_url, project_id)
-    result = _perform_request(url, "get", headers=gitlab_headers)
+    result = _perform_request(url, "get", headers=gitlab_headers, verify=verify)
     if result and isinstance(result, list):
         for milestone in result:
             gitlab_milestones[milestone["title"]] = milestone["id"]
@@ -84,9 +86,9 @@ def _load_milestone_id_cache(project_id, gitlab_url, gitlab_headers):
     return {"gitlab_milestones": gitlab_milestones}
 
 
-def _get_user_id(username, gitlab_url, headers):
+def _get_user_id(username, gitlab_url, headers, verify):
     url = "{}/users?username={}".format(gitlab_url, username)
-    result = _perform_request(url, "get", headers=headers)
+    result = _perform_request(url, "get", headers=headers, verify=verify)
     if result and isinstance(result, list):
         return result[0]["id"]
     else:

--- a/bugzilla2gitlab/config.py
+++ b/bugzilla2gitlab/config.py
@@ -12,7 +12,7 @@ Config = namedtuple('Config', ["gitlab_base_url", "gitlab_project_id",
                                "default_gitlab_labels", "datetime_format_string",
                                "map_operating_system", "map_keywords", "keywords_to_skip",
                                "map_milestones", "milestones_to_skip", "gitlab_milestones",
-                               "dry_run", "include_bugzilla_link", "verify"])
+                               "dry_run", "include_bugzilla_link", "use_bugzilla_id", "verify"])
 
 
 def get_config(path):

--- a/bugzilla2gitlab/models.py
+++ b/bugzilla2gitlab/models.py
@@ -107,7 +107,7 @@ class Issue(object):
         if milestone not in conf.gitlab_milestones:
             url = "{}/projects/{}/milestones".format(conf.gitlab_base_url, conf.gitlab_project_id)
             response = _perform_request(
-                url, "post", headers=self.headers, data={"title": milestone})
+                url, "post", headers=self.headers, data={"title": milestone}, verify=conf.verify)
             conf.gitlab_milestones[milestone] = response["id"]
 
         self.milestone_id = conf.gitlab_milestones[milestone]
@@ -205,7 +205,7 @@ class Issue(object):
         self.headers["sudo"] = self.sudo
 
         response = _perform_request(url, "post", headers=self.headers, data=data, json=True,
-                                    dry_run=conf.dry_run)
+                                    dry_run=conf.dry_run, verify=conf.verify)
 
         if conf.dry_run:
             # assign a random number so that program can continue
@@ -222,7 +222,8 @@ class Issue(object):
         }
         self.headers["sudo"] = self.sudo
 
-        _perform_request(url, "put", headers=self.headers, data=data, dry_run=conf.dry_run)
+        _perform_request(url, "put", headers=self.headers, data=data, dry_run=conf.dry_run,
+                         verify=conf.verify)
 
 
 class Comment(object):
@@ -273,7 +274,7 @@ class Comment(object):
         data = {k: v for k, v in self.__dict__.items() if k in self.data_fields}
 
         _perform_request(url, "post", headers=self.headers, data=data, json=True,
-                         dry_run=conf.dry_run)
+                         dry_run=conf.dry_run, verify=conf.verify)
 
 
 class Attachment(object):
@@ -320,13 +321,13 @@ class Attachment(object):
 
     def save(self):
         url = "{}/attachment.cgi?id={}".format(conf.bugzilla_base_url, self.id)
-        result = _perform_request(url, "get", json=False)
+        result = _perform_request(url, "get", json=False, verify=conf.verify)
         filename = self.parse_file_name(result.headers)
 
         url = "{}/projects/{}/uploads".format(conf.gitlab_base_url, conf.gitlab_project_id)
         f = {"file": (filename, result.content)}
         attachment = _perform_request(url, "post", headers=self.headers, files=f, json=True,
-                                      dry_run=conf.dry_run)
+                                      dry_run=conf.dry_run, verify=conf.verify)
         # For dry run, nothing is uploaded, so upload link is faked just to let the process continue
         upload_link = self.file_description if conf.dry_run else self.parse_upload_link(attachment)
 

--- a/bugzilla2gitlab/models.py
+++ b/bugzilla2gitlab/models.py
@@ -219,7 +219,7 @@ class Issue(object):
             return
 
         self.id = response["iid"]
-        print("created id: %s" % self.id)
+        print("Created issue with id: {}".format(self.id))
 
     def close(self):
         url = "{}/projects/{}/issues/{}".format(conf.gitlab_base_url, conf.gitlab_project_id,

--- a/bugzilla2gitlab/models.py
+++ b/bugzilla2gitlab/models.py
@@ -210,9 +210,6 @@ class Issue(object):
 
         self.headers["sudo"] = self.sudo
 
-        print(self.headers)
-        print(data)
-
         response = _perform_request(url, "post", headers=self.headers, data=data, json=True,
                                     dry_run=conf.dry_run, verify=conf.verify)
 

--- a/bugzilla2gitlab/utils.py
+++ b/bugzilla2gitlab/utils.py
@@ -9,7 +9,7 @@ session = None
 
 
 def _perform_request(url, method, data={}, params={}, headers={}, files={}, json=True,
-                     dry_run=False):
+                     dry_run=False, verify=True):
     '''
     Utility method to perform an HTTP request.
     '''
@@ -25,9 +25,9 @@ def _perform_request(url, method, data={}, params={}, headers={}, files={}, json
     func = getattr(session, method)
 
     if files:
-        result = func(url, files=files, headers=headers)
+        result = func(url, files=files, headers=headers, verify=verify)
     else:
-        result = func(url, params=params, data=data, headers=headers)
+        result = func(url, params=params, data=data, headers=headers, verify=verify)
 
     if result.status_code in [200, 201]:
         if json:

--- a/tests/test_data/config/defaults.yml
+++ b/tests/test_data/config/defaults.yml
@@ -7,6 +7,9 @@ dry_run: true
 # gitlab api base url without trailing slash
 gitlab_base_url: "https://git.example.com/api/v4"
 
+# disable ssl cert verify
+verify: true
+
 # The gitlab project id
 gitlab_project_id: 5
 

--- a/tests/test_data/config/defaults.yml
+++ b/tests/test_data/config/defaults.yml
@@ -7,14 +7,14 @@ dry_run: true
 # gitlab api base url without trailing slash
 gitlab_base_url: "https://git.example.com/api/v4"
 
-# disable ssl cert verify
+# Enable tls certification verification. Disable for local development.
 verify: true
 
 # create gitlab issue with the same id as bugzilla ticket number. Issue id is
 # not auto generated.  The group members which are mapped in the user mappings
 # need to be defined as project owners for this to work. Otherwise the API will
 # ignore IID setting and auto generate the issue id.
-use_bugzilla_id: true
+use_bugzilla_id: false
 
 # The gitlab project id
 gitlab_project_id: 5

--- a/tests/test_data/config/defaults.yml
+++ b/tests/test_data/config/defaults.yml
@@ -13,8 +13,8 @@ verify: true
 # Auto-generate the issue id in Gitlab. If set to `true`, create a Gitlab issue with
 # the same id as the Bugzilla ticket number.  The group members which are 
 # mapped in the user mappings need to be defined as project owners for this
-# to work properly. Otherwise the Gitlab API will ignore the `iid` setting fallback
-# to the default behavior (i.e. auto-generate the issue id).
+# to work properly. Otherwise the Gitlab API will silently ignore the `iid` setting 
+# and fallback to the default behavior (i.e. auto-generate the issue id).
 use_bugzilla_id: false
 
 # The gitlab project id

--- a/tests/test_data/config/defaults.yml
+++ b/tests/test_data/config/defaults.yml
@@ -10,6 +10,12 @@ gitlab_base_url: "https://git.example.com/api/v4"
 # disable ssl cert verify
 verify: true
 
+# create gitlab issue with the same id as bugzilla ticket number. Issue id is
+# not auto generated.  The group members which are mapped in the user mappings
+# need to be defined as project owners for this to work. Otherwise the API will
+# ignore IID setting and auto generate the issue id.
+use_bugzilla_id: true
+
 # The gitlab project id
 gitlab_project_id: 5
 

--- a/tests/test_data/config/defaults.yml
+++ b/tests/test_data/config/defaults.yml
@@ -10,10 +10,11 @@ gitlab_base_url: "https://git.example.com/api/v4"
 # Enable tls certification verification. Disable for local development.
 verify: true
 
-# create gitlab issue with the same id as bugzilla ticket number. Issue id is
-# not auto generated.  The group members which are mapped in the user mappings
-# need to be defined as project owners for this to work. Otherwise the API will
-# ignore IID setting and auto generate the issue id.
+# Auto-generate the issue id in Gitlab. If set to `true`, create a Gitlab issue with
+# the same id as the Bugzilla ticket number.  The group members which are 
+# mapped in the user mappings need to be defined as project owners for this
+# to work properly. Otherwise the Gitlab API will ignore the `iid` setting fallback
+# to the default behavior (i.e. auto-generate the issue id).
 use_bugzilla_id: false
 
 # The gitlab project id


### PR DESCRIPTION
Sometimes during testing it can be useful to disable
ssl certificate verification and turn certificate
related errors into warnings

Introduces new configuration option

 verify:

in defauls.yml with default set to true.