### PR TITLE
Dont use sudo while creating milestones.

### DIFF
--- a/bugzilla2gitlab/models.py
+++ b/bugzilla2gitlab/models.py
@@ -126,10 +126,15 @@ class Issue:
             url = "{}/projects/{}/milestones".format(
                 CONF.gitlab_base_url, CONF.gitlab_project_id
             )
+            """
+            Dont use sudo while creating milestones
+            """
+            header = self.headers
+            del header["sudo"]
             response = _perform_request(
                 url,
                 "post",
-                headers=self.headers,
+                headers=header,
                 data={"title": milestone},
                 verify=CONF.verify,
             )


### PR DESCRIPTION
During migration of some bugzilla tickets i noticed random  403
forbidden errors during milestone creation. Just as during issue
creation, the sudo flag is set for creating a milestone too, means it
attempts to create the milestone with the user the current ticket is
processed (and which was missing some access rights in my case).

As we are using an administrative account for migration anyways its not
requird to set sudo value in the headers and i think it is perfectly
fine to use the project's administrative account to create them.