### PR TITLE
Introduce check if use_bugzilla_id is enabled

### DIFF
--- a/bugzilla2gitlab/models.py
+++ b/bugzilla2gitlab/models.py
@@ -261,6 +261,19 @@ class Issue:
             return
 
         self.id = response["iid"]
+
+        """
+        Check if created issue ID matches requested ID if
+        option to keep numbers is enabled. Otherwise things
+        can become quite messy
+        """
+        if CONF.use_bugzilla_id is True:
+            if self.id != self.bug_id:
+                raise Exception(
+                    "Issue id [{}]!=[{}]: missing  owner permission for gitlab user id {}".format(
+                    self.id, self.bug_id, self.sudo
+                    )
+                )
         print("Created issue with id: {}".format(self.id))
 
     def close(self):


### PR DESCRIPTION
If Option use_bugzilla_id is enabled and one of the sudo users
is missing required ownership, API silently ignores the iid
flag and auto-generates the id.

Introduce check if the generated issue id does not match the
bugzilla bug id, otherwise such situations arent noticed
during migration and things become really messy.