### PR TITLE
Add bug dependencies to bugzilla header

### DIFF
--- a/bugzilla2gitlab/models.py
+++ b/bugzilla2gitlab/models.py
@@ -175,11 +175,11 @@ class Issue:
 
         deplist = ""
         blocklist = ""
-        if fields.get("dependson") is not None:
+        if fields.get("dependson"):
             for depends in fields.get("dependson"):
                 deplist += "[{}]({}) ".format(depends, link)
             self.description += markdown_table_row("Depends On", deplist)
-        if fields.get("blocked") is not None:
+        if fields.get("blocked"):
             for blocked in fields.get("blocked"):
                 blocklist += "[{}]({}) ".format(blocked, link)
             self.description += markdown_table_row("Blocked by", blocklist)

--- a/bugzilla2gitlab/models.py
+++ b/bugzilla2gitlab/models.py
@@ -173,6 +173,15 @@ class Issue:
             "Architecture", fields.get("rep_platform")
         )
 
+        if fields.get("dependson") is not None:
+            self.description += markdown_table_row(
+                "Depends On", "[{}]({})".format(fields.get("dependson"), link)
+            )
+        if fields.get("blocked") is not None:
+            self.description += markdown_table_row(
+                "Blocked by", "[{}]({})".format(fields.get("blocked"), link)
+            )
+
         # add first comment to the issue description
         attachments = []
         to_delete = []

--- a/bugzilla2gitlab/models.py
+++ b/bugzilla2gitlab/models.py
@@ -173,14 +173,16 @@ class Issue:
             "Architecture", fields.get("rep_platform")
         )
 
+        deplist = ""
+        blocklist = ""
         if fields.get("dependson") is not None:
-            self.description += markdown_table_row(
-                "Depends On", "[{}]({})".format(fields.get("dependson"), link)
-            )
+            for depends in fields.get("dependson"):
+                deplist += "[{}]({}) ".format(depends, link)
+            self.description += markdown_table_row("Depends On", deplist)
         if fields.get("blocked") is not None:
-            self.description += markdown_table_row(
-                "Blocked by", "[{}]({})".format(fields.get("blocked"), link)
-            )
+            for blocked in fields.get("blocked"):
+                blocklist += "[{}]({}) ".format(blocked, link)
+            self.description += markdown_table_row("Blocked by", blocklist)
 
         # add first comment to the issue description
         attachments = []

--- a/bugzilla2gitlab/utils.py
+++ b/bugzilla2gitlab/utils.py
@@ -81,7 +81,13 @@ def get_bugzilla_bug(bugzilla_url, bug_id):
     bug_xml = _fetch_bug_content(bugzilla_url, bug_id)
     tree = ElementTree.fromstring(bug_xml)
 
-    bug_fields = {"long_desc": [], "attachment": [], "cc": [], "dependson": []}
+    bug_fields = {
+        "long_desc": [],
+        "attachment": [],
+        "cc": [],
+        "dependson": [],
+        "blocked": [],
+    }
     for bug in tree:
         for field in bug:
             if field.tag in ("long_desc", "attachment"):
@@ -92,6 +98,8 @@ def get_bugzilla_bug(bugzilla_url, bug_id):
             elif field.tag == "cc":
                 bug_fields[field.tag].append(field.text)
             elif field.tag == "dependson":
+                bug_fields[field.tag].append(field.text)
+            elif field.tag == "blocked":
                 bug_fields[field.tag].append(field.text)
             else:
                 bug_fields[field.tag] = field.text

--- a/bugzilla2gitlab/utils.py
+++ b/bugzilla2gitlab/utils.py
@@ -81,11 +81,7 @@ def get_bugzilla_bug(bugzilla_url, bug_id):
     bug_xml = _fetch_bug_content(bugzilla_url, bug_id)
     tree = ElementTree.fromstring(bug_xml)
 
-    bug_fields = {
-        "long_desc": [],
-        "attachment": [],
-        "cc": [],
-    }
+    bug_fields = {"long_desc": [], "attachment": [], "cc": [], "dependson": []}
     for bug in tree:
         for field in bug:
             if field.tag in ("long_desc", "attachment"):
@@ -94,6 +90,8 @@ def get_bugzilla_bug(bugzilla_url, bug_id):
                     new[data.tag] = data.text
                 bug_fields[field.tag].append(new)
             elif field.tag == "cc":
+                bug_fields[field.tag].append(field.text)
+            elif field.tag == "dependson":
                 bug_fields[field.tag].append(field.text)
             else:
                 bug_fields[field.tag] = field.text


### PR DESCRIPTION
Currently during migration dependencies between bugzilla
tickets are lost, no gitlab links are created. Add legacy
information about bug dependencies or blocks to sepzilla
header, at least.