### PR TITLE
Add new option whether datetime should be shown in every comment

### DIFF
--- a/bugzilla2gitlab/config.py
+++ b/bugzilla2gitlab/config.py
@@ -21,6 +21,7 @@ Config = namedtuple(
         "gitlab_users",
         "gitlab_misc_user",
         "default_gitlab_labels",
+        "show_datetime_in_comments",
         "datetime_format_string",
         "map_operating_system",
         "map_keywords",

--- a/bugzilla2gitlab/models.py
+++ b/bugzilla2gitlab/models.py
@@ -310,13 +310,15 @@ class Comment:
         self.sudo = CONF.gitlab_users[CONF.bugzilla_users[fields["who"]]]
         # if unable to comment as the original user, put username in comment body
         self.created_at = format_utc(fields["bug_when"])
+        self.body = ""
         if CONF.bugzilla_users[fields["who"]] == CONF.gitlab_misc_user:
-            self.body = "By {} on {}\n\n".format(
-                fields["who"],
-                format_datetime(fields["bug_when"], CONF.datetime_format_string),
-            )
-        else:
-            self.body = format_datetime(fields["bug_when"], CONF.datetime_format_string)
+            self.body += "By {}".format(fields["who"])
+            if CONF.show_datetime_in_comments:
+              self.body += " on "
+            else:
+              self.body += "\n\n"
+        if CONF.show_datetime_in_comments:
+            self.body += format_datetime(fields["bug_when"], CONF.datetime_format_string)
             self.body += "\n\n"
 
         # if this comment is actually an attachment, upload the attachment and add the

--- a/tests/test_data/config/defaults.yml
+++ b/tests/test_data/config/defaults.yml
@@ -34,6 +34,9 @@ bugzilla_user:
 # if not empty, you will be prompted for password once upon script startup
 bugzilla_password:
 
+# Set to true to show datetime in every comment
+show_datetime_in_comments: true
+
 # The way to format datetime strings in the gitlab issue description and comment body.
 datetime_format_string: "%b %d, %Y %H:%M"
 
@@ -69,6 +72,7 @@ map_keywords: true
 keywords_to_skip:
     - "SKIPME"
     - "NOTHING"
+
 # Set to true to map bugzilla milestones to GitLab
 map_milestones: true
 


### PR DESCRIPTION
When sudo is available on the GitLab instance, the datetime of comments is already correct. So there is no need to show the datetime again in the comment. This PR makes it optional to show datetime in comments.