### PR TITLE
Provides support to allow skipping pre-migrated bugs from bugzilla to…

### DIFF
--- a/bugzilla2gitlab/config.py
+++ b/bugzilla2gitlab/config.py
@@ -32,6 +32,7 @@ Config = namedtuple(
         "include_bugzilla_link",
         "use_bugzilla_id",
         "verify",
+        "gitlab_skip_pre_migrated_issues",
     ],
 )
 

--- a/bugzilla2gitlab/migrator.py
+++ b/bugzilla2gitlab/migrator.py
@@ -18,8 +18,12 @@ class Migrator:
                 self.conf.bugzilla_user,
                 self.conf.bugzilla_password,
             )
+
+        bug_migrated = True # assume true for now
         for bug in bug_list:
-            self.migrate_one(bug)
+            bug_migrated = self.migrate_one(bug)
+
+        return bug_migrated
 
     def migrate_one(self, bugzilla_bug_id):
         """
@@ -28,4 +32,10 @@ class Migrator:
         print("Migrating bug {}".format(bugzilla_bug_id))
         fields = get_bugzilla_bug(self.conf.bugzilla_base_url, bugzilla_bug_id)
         issue_thread = IssueThread(self.conf, fields)
-        issue_thread.save()
+
+        if(self.conf.gitlab_skip_pre_migrated_issues and issue_thread.preexists):
+            print("Bug {} already migrated".format(bugzilla_bug_id))
+            return False
+        else:
+            issue_thread.save()
+            return True

--- a/tests/test_bugzilla2gitlab.py
+++ b/tests/test_bugzilla2gitlab.py
@@ -64,6 +64,9 @@ def test_config(monkeypatch):
     # conf.gitlab_milestones is a dictionary
     assert isinstance(conf.gitlab_milestones, dict)
 
+    #conf.gitlab_skip_pre_migrated_issues is a boolean value
+    assert isinstance(conf.gitlab_skip_pre_migrated_issues, bool)
+
 
 def test_Migrator(monkeypatch):
     bug_id = 103
@@ -88,4 +91,9 @@ def test_Migrator(monkeypatch):
 
     # just test that it works without throwing any exceptions
     client = Migrator(os.path.join(TEST_DATA_PATH, "config"))
-    client.migrate([bug_id])
+    assert (True, client.migrate([bug_id]))
+
+    # Test that the same bug is skipped if it's attempted to migrate again
+    conf = bugzilla2gitlab.config.get_config(os.path.join(TEST_DATA_PATH, "config"))
+    if(conf.gitlab_skip_pre_migrated_issues is True):
+        assert (False, client.migrate([bug_id]))

--- a/tests/test_data/config/defaults.yml
+++ b/tests/test_data/config/defaults.yml
@@ -11,9 +11,9 @@ gitlab_base_url: "https://git.example.com/api/v4"
 verify: true
 
 # Auto-generate the issue id in Gitlab. If set to `true`, create a Gitlab issue with
-# the same id as the Bugzilla ticket number.  The group members which are 
+# the same id as the Bugzilla ticket number.  The group members which are
 # mapped in the user mappings need to be defined as project owners for this
-# to work properly. Otherwise the Gitlab API will silently ignore the `iid` setting 
+# to work properly. Otherwise the Gitlab API will silently ignore the `iid` setting
 # and fallback to the default behavior (i.e. auto-generate the issue id).
 use_bugzilla_id: false
 
@@ -76,3 +76,6 @@ map_milestones: true
 milestones_to_skip:
     - "---"
     - "UNKNOWN"
+
+# Set to true to skip pre-migrated issues
+gitlab_skip_pre_migrated_issues: true


### PR DESCRIPTION
## Related issues:
* This closes #37

## Summary of changes:
* Added a boolean config parameter called `gitlab_skip_pre_migrated_issues` in config.py
* Added a check if the bug has been migrated already by sending a GET request to the gitlab api with a search for the proposed issue `title`.
* Provided a check prior to saving the new `issue` in the Migrator, which will not save the issue if it is already migrated
* Return a boolean from the `Migrator::migrate()` method to see if any bugs were skipped
* Added a check to the config tuple to enforce the new parameter in defaults.yml

## Testing
** Caveat -- This was tested on a production application and works very successfully. 
However, I could not get the pytest to successfully execute with pytest nor pytest-3. This is the output:
![image](https://user-images.githubusercontent.com/45527355/169622964-4eaaa000-34be-413b-b1be-95a56d98e636.png)